### PR TITLE
Fixed python 2 compatibility

### DIFF
--- a/minisom.py
+++ b/minisom.py
@@ -19,7 +19,7 @@ def fast_norm(x):
     return sqrt(dot(x, x.T))
 
 
-class MiniSom:
+class MiniSom(object):
     def __init__(self, x, y, input_len, sigma=1.0, learning_rate=0.5, decay_function=None, random_seed=None):
         """
             Initializes a Self Organizing Maps.


### PR DESCRIPTION
I made the `MiniSom` object inherit from `object` in order to work with derived classes in Python 2. All tests still pass with Python 3.5.1 and Python 2.7.11.