### PR TITLE
fixed it/s indicator (was s/it)

### DIFF
--- a/minisom.py
+++ b/minisom.py
@@ -31,7 +31,7 @@ def _incremental_index_verbose(m):
     beginning = time()
     for i in range(m):
         yield i
-        it_per_sec = (time() - beginning) / (i+1)
+        it_per_sec = (i+1) / (time() - beginning)
         progress = '\r [ {i:{d}} / {m} ]'.format(i=i+1, d=digits, m=m)
         progress += ' {p:3.0f}%'.format(p=100*(i+1)/m)
         progress += ' - {it_per_sec:4.5f} it/s'.format(it_per_sec=it_per_sec)


### PR DESCRIPTION
The "iterations per second" (`it_per_sec`) indicator is actually currently computing the "seconds per iteration", thus displaying something along the lines of `0.0001 it/s`. 

This PR fixes this by correctly computing the number of iterations processed per second. 

The main concern with this PR would be that now `time() - beginning` is at denominator, thus potentially being 0 and raising a `ZeroDivisionError`. I believe this to be a non-problem, since the first computation occurs after a `yield`, thus making it unlikely that `time()` will be the same as `beginning`. Indeed, even a simpler code such as:
```python
a = time()
for i in range(10):
  print(time() - a)
```
will likely (tested on different machines) print numbers greater than 1e-5 (b/c of course calling the `range` function and starting the iteration takes time). 

If this is still a concern, a small delta can be added to the denominator, or the "seconds per iteration" indicator could be used instead (though it would be much less cool). 