### PR TITLE
My thoughts on train_batch for discussion

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,8 @@ som.train_random(data, 100) # trains the SOM with 100 iterations
 
 MiniSom implements two types of training. The random training (implemented by the method `train_random`), where the model is trained picking random samples (i.e. rows) from your data, and the batch training (implemented by the method `train_batch`), where the samples are picked in the order they are stored. For `train_random`, it will just pick the iteration number of samples for training. For `train_batch`, it will pick the iteration number of data for training so that all samples in the data can be fairly considered.
 
+**Note that the author of the minisom disagreed with my change of iterations to `train_batch` so as to use the same parameters for `train_random` and `train_batch`. I agree with this too. As an alternative, I can transfer num_iteration parameter as a certain number multiply by len(data). idx calculation in `train_batch` has been updated!**
+
 The weights of the network are randmly initialized by default. Two additional methods are provided to initialize the weights in a data driven fashion: `random_weights_init` and `pca_weights_init`.
 
 ### Using the trained SOM

--- a/Readme.md
+++ b/Readme.md
@@ -36,11 +36,11 @@ data = [[ 0.80,  0.55,  0.22,  0.03],
 
 ```python
 from minisom import MiniSom    
-som = MiniSom(6, 6, 4, sigma=0.3, learning_rate=0.5) # initialization of 6x6 SOM
+som = MiniSom(6, 6, 4, sigma=0.3, learning_rate=0.5) # initialization of 6x6 SOM with an input of dimension of 4 for training. The initial sigma and learning rate are 0.3 and 0.5, respectively.
 som.train_random(data, 100) # trains the SOM with 100 iterations
 ```
 
-MiniSom implements two types of training. The random training (implemented by the method `train_random`), where the model is trained picking random samples from your data, and the batch training (implemented by the method `train_batch`), where the samples are picked in the order they are stored.
+MiniSom implements two types of training. The random training (implemented by the method `train_random`), where the model is trained picking random samples (i.e. rows) from your data, and the batch training (implemented by the method `train_batch`), where the samples are picked in the order they are stored. For `train_random`, it will just pick the iteration number of samples for training. For `train_batch`, it will pick the iteration number of data for training so that all samples in the data can be fairly considered.
 
 The weights of the network are randmly initialized by default. Two additional methods are provided to initialize the weights in a data driven fashion: `random_weights_init` and `pca_weights_init`.
 

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,11 @@ som.train_random(data, 100) # trains the SOM with 100 iterations
 
 MiniSom implements two types of training. The random training (implemented by the method `train_random`), where the model is trained picking random samples (i.e. rows) from your data, and the batch training (implemented by the method `train_batch`), where the samples are picked in the order they are stored. For `train_random`, it will just pick the iteration number of samples for training. For `train_batch`, it will pick the iteration number of data for training so that all samples in the data can be fairly considered.
 
-**Note that the author of the minisom disagreed with my change of iterations to `train_batch` so as to use the same parameters for `train_random` and `train_batch`. I agree with this too. As an alternative, I can transfer num_iteration parameter as a certain number multiply by len(data). idx calculation in `train_batch` has been updated!**
+**Note that the author of the minisom disagreed with my change of iterations to `train_batch` so as to use the same parameters for `train_random` and `train_batch`. I agree with this too. As an alternative, I can transfer num_iteration parameter as a certain number multiply by len(data).**
+
+**Also note that idx calculation in original `train_batch` is wrong and to fix it without re-install minisom is as follows.**
+1. Find the path of minisom in Python environment using `import minisom; print(minisom.__file__)`
+2. Open the `minisom.py` and fix the bugs.
 
 The weights of the network are randmly initialized by default. Two additional methods are provided to initialize the weights in a data driven fashion: `random_weights_init` and `pca_weights_init`.
 

--- a/minisom.py
+++ b/minisom.py
@@ -95,7 +95,7 @@ class MiniSom(object):
             to the dimensions of the map.
             (at the iteration t we have sigma(t) = sigma / (1 + t/T)
             where T is #num_iteration/2)
-            learning_rate, initial learning rate
+        learning_rate: initial learning rate
             (at the iteration t we have
             learning_rate(t) = learning_rate / (1 + t/T)
             where T is #num_iteration/2)
@@ -332,12 +332,12 @@ class MiniSom(object):
         """
         self._check_iteration_number(num_iteration)
         self._check_input_len(data)
-        iterations = range(num_iteration)
+        iterations = range(num_iteration*len(data)) # For each iteration, we go through all data samples, so we ensure each sample in the data be fairly considered.
         if verbose:
             iterations = _incremental_index_verbose(num_iteration)
 
         for iteration in iterations:
-            idx = iteration % (len(data)-1)
+            idx = iteration % (len(data)) # I think the denominator should just be len(data) otherwise data[-1] cannot be incorporated.
             self.update(data[idx], self.winner(data[idx]),
                         iteration, num_iteration)
         if verbose:


### PR DESCRIPTION
1. Improve the __doc__ of MiniSom.
2. It might be better to multiply the iterations by len(data) so that each sample in the data can be fairly considered (see page. 12 in https://schunternet.de/~krusty/sompaper.pdf). Nevertheless, when iterations is much larger than len(data), the influence might be ignored.
3. Corresponding changes for the README.md have also been made for you to check.