### PR TITLE
Add documentation for MiniSom class

### DIFF
--- a/minisom.py
+++ b/minisom.py
@@ -136,7 +136,7 @@ class MiniSom(object):
 
         neighborhood_function : function, optional (default='gaussian')
             Function that weights the neighborhood of a position in the map
-            possible values: 'gaussian', 'mexican_hat', 'bubble'
+            possible values: 'gaussian', 'mexican_hat', 'bubble', 'triangle'
 
         random_seed : int, optional (default=None)
             Random seed to use.


### PR DESCRIPTION
After introducing 2bf82df9d "triangle" was not added in the docstring.