### PR TITLE
added return_indices parameter to win_map()

### DIFF
--- a/minisom.py
+++ b/minisom.py
@@ -520,13 +520,17 @@ class MiniSom(object):
         distance = norm(dxdy, axis=1)
         return (distance > t).mean()
 
-    def win_map(self, data):
+    def win_map(self, data, return_indices=False):
         """Returns a dictionary wm where wm[(i,j)] is a list
-        with all the patterns that have been mapped in the position i,j."""
+        with:
+        - all the patterns that have been mapped in the position (i,j),
+          if return_indices=False (default)
+        - all indices of the elements that have been mapped to the
+          position (i,j) if return_indices=True"""
         self._check_input_len(data)
         winmap = defaultdict(list)
-        for x in data:
-            winmap[self.winner(x)].append(x)
+        for i, x in enumerate(data):
+            winmap[self.winner(x)].append(i if return_indices else x)
         return winmap
 
     def labels_map(self, data, labels):
@@ -643,6 +647,11 @@ class TestMinisom(unittest.TestCase):
         winners = self.som.win_map([[5.0], [2.0]])
         assert winners[(2, 3)][0] == [5.0]
         assert winners[(1, 1)][0] == [2.0]
+
+    def test_win_map_indices(self):
+        winners = self.som.win_map([[5.0], [2.0]], return_indices=True)
+        assert winners[(2, 3)] == [0]
+        assert winners[(1, 1)] == [1]
 
     def test_labels_map(self):
         labels_map = self.som.labels_map([[5.0], [2.0]], ['a', 'b'])

--- a/minisom.py
+++ b/minisom.py
@@ -521,9 +521,8 @@ class MiniSom(object):
         return (distance > t).mean()
 
     def win_map(self, data, return_indices=False):
-        """Returns a dictionary wm where wm[(i,j)] is a list
-        with:
-        - all the patterns that have been mapped in the position (i,j),
+        """Returns a dictionary wm where wm[(i,j)] is a list with:
+        - all the patterns that have been mapped to the position (i,j),
           if return_indices=False (default)
         - all indices of the elements that have been mapped to the
           position (i,j) if return_indices=True"""


### PR DESCRIPTION
This PR introduces the parameter `return_indices` for the `win_map()` method. 

I believe this option to be particularly useful because:

1. it allows accessing arrays other than `data`. For example, I might have a `labels` array (with the labels for the points in `data`). I can now do the following:
```python
wm = som.win_map(data, return_indices=True)
labels_0_0 = labels[wm[0,0]]
data_0_0 = data[wm[0,0]] # <= this is what is returned by win_map() with return_indices=False (previous behavior)
```
2. It prevents unnecessary duplications of data which, in case of hefty datasets, might be a problem memory-wise

The default value for `win_map()` is the current one for backward compatibility (though I would recommend using `return_indices=True` from now on)