### PR TITLE
Introducing possibility to train the SOM so that learning_rate and sigma are constant during one epoch.

### DIFF
--- a/minisom.py
+++ b/minisom.py
@@ -42,23 +42,6 @@ def _build_iteration_indexes(data_len, num_iterations,
         return iterations
 
 
-def _build_iteration_indexes_alternative(data_len,
-                             verbose=False, random_generator=None):
-    """Returns an iterable with the indexes of the samples
-    to pick at each iteration of the training.
-
-    If random_generator is not None, it must be an instalce
-    of numpy.random.RandomState and it will be used
-    to randomize the order of the samples."""
-    iterations = arange(data_len)
-    if random_generator:
-        random_generator.shuffle(iterations)
-    if verbose:
-        return _wrap_index__in_verbose(iterations)
-    else:
-        return iterations
-
-
 def _wrap_index__in_verbose(iterations):
     """Yields the values in iterations printing the status on the stdout."""
     m = len(iterations)
@@ -309,6 +292,10 @@ class MiniSom(object):
     def _check_iteration_number(self, num_iteration):
         if num_iteration < 1:
             raise ValueError('num_iteration must be > 1')
+    
+    def _check_epoch_number(self, num_epoch):
+        if num_epoch < 1:
+            raise ValueError('num_epoch must be > 1')
 
     def _check_input_len(self, data):
         """Checks that the data in input is of the correct shape."""
@@ -341,25 +328,6 @@ class MiniSom(object):
         eta = self._decay_function(self._learning_rate, t, max_iteration)
         # sigma and learning rate decrease with the same rule
         sig = self._decay_function(self._sigma, t, max_iteration)
-        # improves the performances
-        g = self.neighborhood(win, sig)*eta
-        # w_new = eta * neighborhood_function * (x-w)
-        self._weights += einsum('ij, ijk->ijk', g, x-self._weights)
-
-    def update_alternative(self, x, win, eta, sig):
-        """Updates the weights of the neurons.
-
-        Parameters
-        ----------
-        x : np.array
-            Current pattern to learn.
-        win : tuple
-            Position of the winning neuron for x (array or tuple).
-        t : int
-            Iteration index
-        max_iteration : int
-            Maximum number of training itarations.
-        """
         # improves the performances
         g = self.neighborhood(win, sig)*eta
         # w_new = eta * neighborhood_function * (x-w)
@@ -429,16 +397,13 @@ class MiniSom(object):
         random_generator = None
         if random_order:
             random_generator = self._random_generator
-        iterations = _build_iteration_indexes_alternative(len(data),
+        iterations = _build_iteration_indexes(len(data), num_iteration,
                                               verbose, random_generator)
-        for i in range(0, num_iteration):
-            eta = self._decay_function(self._learning_rate, i, num_iteration)
-            sig = self._decay_function(self._sigma, i, num_iteration)
-            for t, iteration in enumerate(iterations):
-                self.update_alternative(data[iteration], self.winner(data[iteration]),
-                            eta, sig)
-            if verbose:
-                print('\n quantization error:', self.quantization_error(data))
+        for t, iteration in enumerate(iterations):
+            self.update(data[iteration], self.winner(data[iteration]),
+                        t, num_iteration)
+        if verbose:
+            print('\n quantization error:', self.quantization_error(data))
 
     def train_random(self, data, num_iteration, verbose=False):
         """Trains the SOM picking samples at random from data.
@@ -473,6 +438,40 @@ class MiniSom(object):
             will be printed at each iteration.
         """
         self.train(data, num_iteration, random_order=False, verbose=verbose)
+
+    def train_epochs(self, data, num_epoch, random_order=False, verbose=False):
+        """Trains the SOM while decreasing eta and sigma (only) every epoch.
+
+        Parameters
+        ----------
+        data : np.array or list
+            Data matrix.
+
+        num_epoch : int
+            number of epochs
+
+        random_order : bool (default=False)
+            If True, samples are picked in random order.
+            Otherwise the samples are picked sequentially.
+
+        verbose : bool (default=False)
+            If True the status of the training
+            will be printed at each iteration.
+        """
+        self._check_epoch_number(num_epoch)
+        self._check_input_len(data)
+
+        iterations = arange(len(data))
+        if random_order:
+            random_generator = self._random_generator
+            random_generator.shuffle(iterations)
+            
+        for i in range(0, num_epoch):
+            for t, iteration in enumerate(iterations):
+                self.update(data[iteration], self.winner(data[iteration]),
+                        i, num_epoch)
+            if verbose:
+                print('\n quantization error:', self.quantization_error(data))
 
     def distance_map(self, scaling='sum'):
         """Returns the distance map of the weights.

--- a/minisom.py
+++ b/minisom.py
@@ -470,8 +470,8 @@ class MiniSom(object):
             for t, iteration in enumerate(iterations):
                 self.update(data[iteration], self.winner(data[iteration]),
                         i, num_epoch)
-            if verbose:
-                print('\n quantization error:', self.quantization_error(data))
+        if verbose:
+            print('\n quantization error:', self.quantization_error(data))
 
     def distance_map(self, scaling='sum'):
         """Returns the distance map of the weights.
@@ -803,7 +803,7 @@ class TestMinisom(unittest.TestCase):
 
         data = array([[1, 5], [6, 7]])
         q1 = som.quantization_error(data)
-        som.train_epochs(data, 10, verbose=True)
+        som.train_epochs(data, 5, verbose=True)
         assert q1 > som.quantization_error(data)
 
     def test_random_weights_init(self):

--- a/minisom.py
+++ b/minisom.py
@@ -794,6 +794,18 @@ class TestMinisom(unittest.TestCase):
         som.train_random(data, 10, verbose=True)
         assert q1 > som.quantization_error(data)
 
+    def test_train_epoch(self):
+        som = MiniSom(5, 5, 2, sigma=1.0, learning_rate=0.5, random_seed=1)
+        data = array([[4, 2], [3, 1]])
+        q1 = som.quantization_error(data)
+        som.train(data, 10, random_order=True)
+        assert q1 > som.quantization_error(data)
+
+        data = array([[1, 5], [6, 7]])
+        q1 = som.quantization_error(data)
+        som.train_epochs(data, 10, verbose=True)
+        assert q1 > som.quantization_error(data)
+
     def test_random_weights_init(self):
         som = MiniSom(2, 2, 2, random_seed=1)
         som.random_weights_init(array([[1.0, .0]]))

--- a/minisom.py
+++ b/minisom.py
@@ -292,7 +292,7 @@ class MiniSom(object):
     def _check_iteration_number(self, num_iteration):
         if num_iteration < 1:
             raise ValueError('num_iteration must be > 1')
-    
+
     def _check_epoch_number(self, num_epoch):
         if num_epoch < 1:
             raise ValueError('num_epoch must be > 1')
@@ -465,11 +465,11 @@ class MiniSom(object):
         if random_order:
             random_generator = self._random_generator
             random_generator.shuffle(iterations)
-            
+
         for i in range(0, num_epoch):
             for t, iteration in enumerate(iterations):
                 self.update(data[iteration], self.winner(data[iteration]),
-                        i, num_epoch)
+                            i, num_epoch)
         if verbose:
             print('\n quantization error:', self.quantization_error(data))
 


### PR DESCRIPTION
This pull request introduces the possibility to train the SOM so that learning_rate and sigma are only being decreased after each epoch. During one epoch the SOM is updated once per given input vector (=len(data) times) with constant learning_rate and sigma. This should lead to a greater independence between the order of the input vectors and the resulting SOM.

In order to use this feature, one only has to use train_epochs() instead of train().

learning_rate and sigma could (should?) technically be updated only once every epoch but in order to change as little code as possible those parameters are still updated every time update() gets called (but with constant paramters during one epoch). This could be 'optimised' if desired.