### PR TITLE
Add topographic error calculation for hexagonal grid

### DIFF
--- a/minisom.py
+++ b/minisom.py
@@ -530,20 +530,20 @@ class MiniSom(object):
             return self._topographic_error_hexagonal(data)
         else:
             return self._topographic_error_rectangular(data)
-    
+
     def _topographic_error_hexagonal(self, data):
         """Return the topographic error for hexagonal grid"""
         b2mu_inds = argsort(self._distance_from_weights(data), axis=1)[:, :2]
-        b2mu_coords = [[self._get_euclidean_coordinates_from_index(bmu[0]), 
-                        self._get_euclidean_coordinates_from_index(bmu[1])] 
-                            for bmu in b2mu_inds]
+        b2mu_coords = [[self._get_euclidean_coordinates_from_index(bmu[0]),
+                        self._get_euclidean_coordinates_from_index(bmu[1])]
+                        for bmu in b2mu_inds]
         b2mu_coords = array(b2mu_coords)
-        b2mu_neighbors = [(bmu1 >= bmu2-1) & ((bmu1 <= bmu2+1)) 
-                            for bmu1, bmu2 in b2mu_coords]
+        b2mu_neighbors = [(bmu1 >= bmu2-1) & ((bmu1 <= bmu2+1))
+                          for bmu1, bmu2 in b2mu_coords]
         b2mu_neighbors = [neighbors.prod() for neighbors in b2mu_neighbors]
         te = 1 - mean(b2mu_neighbors)
         return te
-    
+
     def _topographic_error_rectangular(self, data):
         """Return the topographic error for rectangular grid"""
         t = 1.42
@@ -554,14 +554,14 @@ class MiniSom(object):
         dxdy = hstack([diff(b2mu_x), diff(b2mu_y)])
         distance = norm(dxdy, axis=1)
         return (distance > t).mean()
-        
+
     def _get_euclidean_coordinates_from_index(self, index):
         """Returns the Euclidean coordinated of a neuron using its
         index as the input"""
         if index < 0:
             return (-1, -1)
         y = self._weights.shape[1]
-        coords = self.convert_map_to_euclidean((index%y, int(index/y)))
+        coords = self.convert_map_to_euclidean((index % y, int(index/y)))
         return coords
 
     def win_map(self, data, return_indices=False):

--- a/minisom.py
+++ b/minisom.py
@@ -536,7 +536,7 @@ class MiniSom(object):
         b2mu_inds = argsort(self._distance_from_weights(data), axis=1)[:, :2]
         b2mu_coords = [[self._get_euclidean_coordinates_from_index(bmu[0]),
                         self._get_euclidean_coordinates_from_index(bmu[1])]
-                        for bmu in b2mu_inds]
+                       for bmu in b2mu_inds]
         b2mu_coords = array(b2mu_coords)
         b2mu_neighbors = [(bmu1 >= bmu2-1) & ((bmu1 <= bmu2+1))
                           for bmu1, bmu2 in b2mu_coords]

--- a/minisom.py
+++ b/minisom.py
@@ -527,8 +527,25 @@ class MiniSom(object):
             warn('The topographic error is not defined for a 1-by-1 map.')
             return nan
         if self.topology == 'hexagonal':
-            return self.topographic_error_hexagonal(data)
-
+            return self._topographic_error_hexagonal(data)
+        else:
+            return self._topographic_error_rectangular(data)
+    
+    def _topographic_error_hexagonal(self, data):
+        """Return the topographic error for hexagonal grid"""
+        b2mu_inds = argsort(self._distance_from_weights(data), axis=1)[:, :2]
+        b2mu_coords = [[self._get_euclidean_coordinates_from_index(bmu[0]), 
+                        self._get_euclidean_coordinates_from_index(bmu[1])] 
+                            for bmu in b2mu_inds]
+        b2mu_coords = array(b2mu_coords)
+        b2mu_neighbors = [(bmu1 >= bmu2-1) & ((bmu1 <= bmu2+1)) 
+                            for bmu1, bmu2 in b2mu_coords]
+        b2mu_neighbors = [neighbors.prod() for neighbors in b2mu_neighbors]
+        te = 1 - mean(b2mu_neighbors)
+        return te
+    
+    def _topographic_error_rectangular(self, data):
+        """Return the topographic error for rectangular grid"""
         t = 1.42
         # b2mu: best 2 matching units
         b2mu_inds = argsort(self._distance_from_weights(data), axis=1)[:, :2]
@@ -537,21 +554,8 @@ class MiniSom(object):
         dxdy = hstack([diff(b2mu_x), diff(b2mu_y)])
         distance = norm(dxdy, axis=1)
         return (distance > t).mean()
-    
-    def topographic_error_hexagonal(self, data):
-        """Return the topographic error for hexagonal grid"""
-        b2mu_inds = argsort(self._distance_from_weights(data), axis=1)[:, :2]
-        b2mu_coords = [[self.get_euclidean_coordinates_from_index(bmu[0]), 
-                        self.get_euclidean_coordinates_from_index(bmu[1])] 
-                            for bmu in b2mu_inds]
-        b2mu_coords = array(b2mu_coords)
-        b2mu_neighbors = [(bmu1 >= bmu2-1) & ((bmu1 <= bmu2+1)) 
-                            for bmu1, bmu2 in b2mu_coords]
-        b2mu_neighbors = [neighbors.prod() for neighbors in b2mu_neighbors]
-        te = 1 - mean(b2mu_neighbors)
-        return te
         
-    def get_euclidean_coordinates_from_index(self, index):
+    def _get_euclidean_coordinates_from_index(self, index):
         """Returns the Euclidean coordinated of a neuron using its
         index as the input"""
         if index < 0:


### PR DESCRIPTION
This PR adds the functionality for Topographic Error calculation, computed by finding the first-best-matching and second-best-matching neurons in the hexagonal grid. 


![Screenshot 2022-04-12 005139](https://user-images.githubusercontent.com/43146932/162814233-e9b65ef4-6eb2-48b5-b859-2eee7b462982.png)

The topographic error calculation is based on the above equation, which considers if the first-best-matching and second-best-matching neurons are neighbors in the SOM grid.
